### PR TITLE
Change drag dataKey to 'text'

### DIFF
--- a/src/events/createOnDragStart.js
+++ b/src/events/createOnDragStart.js
@@ -1,4 +1,4 @@
-export const dataKey = 'value'
+export const dataKey = 'text'
 const createOnDragStart =
   (name, value) =>
     event => {


### PR DESCRIPTION
Bumped into https://github.com/erikras/redux-form/issues/1088 and the solution to stop these errors (and to unbreak drag and drop on IE) is to just change the dataKey to 'text. 

The [stack overflow question](http://stackoverflow.com/questions/26213011/html5-dragdrop-issue-in-internet-explorer-datatransfer-property-access-not-pos) mentioned in the referenced issue suggests this as well FWIW.